### PR TITLE
[fix] No pysub 1.8.0

### DIFF
--- a/validator/requirements.txt
+++ b/validator/requirements.txt
@@ -1,4 +1,4 @@
-substrate-interface
+substrate-interface!=1.8.0
 async_substrate_interface
 aiohttp
 asyncpg


### PR DESCRIPTION
pysub 1.8.0 had a syntax error: https://github.com/JAMdotTech/py-polkadot-sdk/pull/425

fixes: https://github.com/manifold-inc/hone/issues/24